### PR TITLE
Allow to defined the Docker registry token

### DIFF
--- a/paclair/ancestries/docker.py
+++ b/paclair/ancestries/docker.py
@@ -16,7 +16,7 @@ class DockerAncestry(GenericAncestry):
         super().__init__("", "Docker")
 
         # headers
-        headers = {'Authorization': "{} {}".format(docker_image.token_type, docker_image.token)}
+        headers = {'Authorization': "{}".format(docker_image.authorization)}
         partial_path = docker_image.registry.get_blobs_url(docker_image, '{digest}')
 
         # Create layers

--- a/paclair/ancestries/docker.py
+++ b/paclair/ancestries/docker.py
@@ -16,7 +16,7 @@ class DockerAncestry(GenericAncestry):
         super().__init__("", "Docker")
 
         # headers
-        headers = {'Authorization': "Bearer {}".format(docker_image.token)}
+        headers = {'Authorization': "{} {}".format(docker_image.token_type, docker_image.token)}
         partial_path = docker_image.registry.get_blobs_url(docker_image, '{digest}')
 
         # Create layers

--- a/paclair/docker/docker_image.py
+++ b/paclair/docker/docker_image.py
@@ -43,6 +43,15 @@ class DockerImage(LoggedObject):
         return self.registry.get_token(self)
 
     @property
+    def token_type(self):
+        """
+        Token Type for this image
+
+        :return:
+        """
+        return self.registry.get_token_type()
+
+    @property
     def sha(self):
         """
         Sha256 of the layers list (used for clair layer_name)

--- a/paclair/docker/docker_image.py
+++ b/paclair/docker/docker_image.py
@@ -34,22 +34,13 @@ class DockerImage(LoggedObject):
         self.logger.debug("INITCLASS:REPOSITORY:{repository}".format(repository=self.repository))
 
     @property
-    def token(self):
+    def authorization(self):
         """
         Token for this image
 
         :return:
         """
-        return self.registry.get_token(self)
-
-    @property
-    def token_type(self):
-        """
-        Token Type for this image
-
-        :return:
-        """
-        return self.registry.get_token_type()
+        return self.registry.get_authorization(self)
 
     @property
     def sha(self):

--- a/paclair/docker/docker_registry.py
+++ b/paclair/docker/docker_registry.py
@@ -19,7 +19,7 @@ class DockerRegistry(LoggedObject):
     BLOBS_URI = '/v2/{image.name}/blobs/{digest}'
     TOKEN_REGEX = "Bearer realm=\"(?P<realm>.*)\",service=\"(?P<service>.*)\""
 
-    def __init__(self, domain, token_url=None, api_prefix="", protocol="https", auth=None, verify=True, token=None, token_type='Basic'):
+    def __init__(self, domain, token_url=None, api_prefix="", protocol="https", auth=None, verify=True, token=None, token_type='Bearer'):
         """
         Constructor
 

--- a/paclair/docker/docker_registry.py
+++ b/paclair/docker/docker_registry.py
@@ -19,7 +19,7 @@ class DockerRegistry(LoggedObject):
     BLOBS_URI = '/v2/{image.name}/blobs/{digest}'
     TOKEN_REGEX = "Bearer realm=\"(?P<realm>.*)\",service=\"(?P<service>.*)\""
 
-    def __init__(self, domain, token_url=None, api_prefix="", protocol="https", auth=None, verify=True, token=None):
+    def __init__(self, domain, token_url=None, api_prefix="", protocol="https", auth=None, verify=True, token=None, token_type='Basic'):
         """
         Constructor
 
@@ -43,6 +43,8 @@ class DockerRegistry(LoggedObject):
         self.logger.debug("INITCLASS:TOKEN_URL:{}".format(self.__token_url))
         self.__token = token
         self.logger.debug("INITCLASS:TOKEN:{}".format(self.__token))
+        self.__token_type = token_type
+        self.logger.debug("INITCLASS:TOKEN_TYPE:{}".format(self.__token_type))
 
     @property
     def token_url(self):
@@ -125,6 +127,9 @@ class DockerRegistry(LoggedObject):
             return token
         return self.__token
 
+    def get_token_type(self):
+        return self.__token_type
+
     def get_manifest(self, docker_image):
         """
         Get manifest
@@ -138,7 +143,11 @@ class DockerRegistry(LoggedObject):
 
         # Get token
         token = self.get_token(docker_image)
-        resp = requests.get(url, verify=self.verify, headers={"Authorization": "Bearer {}".format(token)})
+        resp = requests.get(
+            url,
+            verify=self.verify,
+            headers={"Authorization": "{} {}".format(self.__token_type, token)}
+        )
 
         if not resp.ok:
             self.logger.error("MANIFESTS:HTTPCODEERROR:{}".format(resp.status_code))

--- a/paclair/docker/docker_registry.py
+++ b/paclair/docker/docker_registry.py
@@ -103,7 +103,7 @@ class DockerRegistry(LoggedObject):
         url = self.get_base_api_url(docker_image) + self.BLOBS_URI.format(image=docker_image, digest=digest)
         return url
 
-    def get_token(self, docker_image):
+    def get_authorization(self, docker_image):
         """
         Get token
 
@@ -124,11 +124,9 @@ class DockerRegistry(LoggedObject):
 
             token = resp.json()['token']
             self.logger.debug("TOKEN:{token}".format(token=token))
-            return token
-        return self.__token
-
-    def get_token_type(self):
-        return self.__token_type
+        else:
+            token = self.__token
+        return "{token_type} {token}".format(token_type=self.__token_type, token=token)
 
     def get_manifest(self, docker_image):
         """
@@ -142,11 +140,11 @@ class DockerRegistry(LoggedObject):
         self.logger.debug("REQUESTMANIFESTS:{url}".format(url=url))
 
         # Get token
-        token = self.get_token(docker_image)
+        token = self.get_authorization(docker_image)
         resp = requests.get(
             url,
             verify=self.verify,
-            headers={"Authorization": "{} {}".format(self.__token_type, token)}
+            headers={"Authorization": "{}".format(token)}
         )
 
         if not resp.ok:

--- a/paclair_tests/test_docker.py
+++ b/paclair_tests/test_docker.py
@@ -158,7 +158,7 @@ class TestDockerImage(unittest.TestCase):
         Test de la méthode get_token
         """
         domain_lambda = 'registery.host'
-        registry = DockerRegistry(domain_lambda, token=self.token)
+        registry = DockerRegistry(domain_lambda, token=self.token, token_type='Basic')
         image = DockerImage('monimage', registry)
         # Manifest
         m.register_uri('GET', registry.get_manifest_url(image), json=self.manifestv2_json,

--- a/paclair_tests/test_docker.py
+++ b/paclair_tests/test_docker.py
@@ -155,7 +155,7 @@ class TestDockerImage(unittest.TestCase):
     @requests_mock.mock()
     def test_get_token(self, m):
         """
-        Test de la méthode get_layer
+        Test de la méthode get_token
         """
         domain_lambda = 'registery.host'
         registry = DockerRegistry(domain_lambda, token=self.token)

--- a/paclair_tests/test_docker.py
+++ b/paclair_tests/test_docker.py
@@ -153,6 +153,22 @@ class TestDockerImage(unittest.TestCase):
         self.assertEqual(layers, self.EXPECTED_LAYERS_V2)
 
     @requests_mock.mock()
+    def test_get_token(self, m):
+        """
+        Test de la méthode get_layer
+        """
+        domain_lambda = 'registery.host'
+        registry = DockerRegistry(domain_lambda, token=self.token)
+        image = DockerImage('monimage', registry)
+        # Manifest
+        m.register_uri('GET', registry.get_manifest_url(image), json=self.manifestv2_json,
+                       request_headers={'Authorization': 'Bearer {token}'.format(token=self.token)})
+
+        layers = image.get_layers()
+        self.assertTrue(m.called)
+        self.assertEqual(layers, self.EXPECTED_LAYERS_V2)
+
+    @requests_mock.mock()
     def test_manifest_http_error(self, m):
         """
         Http Error en cas d'erreur d'accès à la registry

--- a/paclair_tests/test_docker.py
+++ b/paclair_tests/test_docker.py
@@ -162,7 +162,7 @@ class TestDockerImage(unittest.TestCase):
         image = DockerImage('monimage', registry)
         # Manifest
         m.register_uri('GET', registry.get_manifest_url(image), json=self.manifestv2_json,
-                       request_headers={'Authorization': 'Bearer {token}'.format(token=self.token)})
+                       request_headers={'Authorization': 'Basic {token}'.format(token=self.token)})
 
         layers = image.get_layers()
         self.assertTrue(m.called)

--- a/paclair_tests/test_docker_plugins.py
+++ b/paclair_tests/test_docker_plugins.py
@@ -21,7 +21,7 @@ class TestDockerPlugin(unittest.TestCase):
         m.post(self.docker.clair.url + self.docker.clair._CLAIR_POST_URI,
                status_code=201, reason="OK")
         with patch.object(DockerImage, "get_layers", return_value=get_layers):
-            with patch.object(DockerImage, "token", return_value="MYTOKEN"):
+            with patch.object(DockerImage, "authorization", return_value="Basic MYTOKEN"):
                 self.docker.push('monimage:tags')
 
     @requests_mock.mock()
@@ -30,5 +30,5 @@ class TestDockerPlugin(unittest.TestCase):
         m.post(self.docker.clair.url + self.docker.clair._CLAIR_POST_URI,
                status_code=404, reason="Not Found")
         with patch.object(DockerImage, "get_layers", return_value=get_layers):
-            with patch.object(DockerImage, "token", return_value="MYTOKEN"), self.assertRaises(ResourceNotFoundException):
+            with patch.object(DockerImage, "authorization", return_value="Basic MYTOKEN"), self.assertRaises(ResourceNotFoundException):
                 self.docker.push('monimage:tags')


### PR DESCRIPTION
Since some Docker registry like `AWS ECR` not provide a Token URL, we can push to `clair` some layer to analyse from the private registry.

In order to allow `paclair` to retrive private docker image layer from `AWS ECR`, this Pull Request propose to allow to define the  ̀token` using conf.

In a our case, we may use the `AWS CLI` to fetch this token, then inject it to `paclair`. 