### PR TITLE
Support registries running on non-standard ports

### DIFF
--- a/paclair/plugins/docker_plugin.py
+++ b/paclair/plugins/docker_plugin.py
@@ -29,7 +29,7 @@ class DockerPlugin(AbstractPlugin):
         self.__registries = {domain: DockerRegistry(domain, **conf) for domain, conf in registries.items()}
         self.__docker_hub = DockerRegistry(DOCKER_HUB_DOMAIN)
         self._pattern = re.compile(REGEX['domain'] + REGEX['name'] + REGEX['tag'])
-        self._domain_pattern = re.compile(r'(?P<repository>[a-zA-Z0-9-]*)\.(?P<domain>[a-zA-Z0-9-.]*)$')
+        self._domain_pattern = re.compile(r'(?P<repository>[a-zA-Z0-9-]*)\.(?P<domain>[a-zA-Z0-9-.]*)[:0-9]*$')
 
     def create_docker_image(self, name):
         """


### PR DESCRIPTION
To correctly parse out the domain for a registry running on a non-standard port (which is a common private GitLab configuration), we need to account for a possible port number.