### PR TITLE
Include example for a private GitLab server

### DIFF
--- a/conf/example_conf.yml
+++ b/conf/example_conf.yml
@@ -12,3 +12,14 @@ Plugins:
         auth:
           - "*****"
           - "*****"
+      # Example for a private gitlab server
+      gitlab.example.com:4567:
+        # note that the token_url contains the container name in the scope argument
+        # See also: http://www.pimwiddershoven.nl/entry/request-an-api-bearer-token-from-gitlab-jwt-authentication-to-control-your-private-docker-registry
+        token_url: 'https://gitlab.example.com/jwt/auth?client_id=docker&offline_token=true&service=container_registry&scope=repository:projectname/repo/containername:pull'
+        protocol: 'https'
+        # If using https with an internal CA, ensure verify is pointing to it
+        verify: "/etc/ssl/certs/ca-certificates.crt"
+        auth:
+          - "*****"
+          - "*****"


### PR DESCRIPTION
After struggling for a day to get Clair + paclair working with a private, internal GitLab-hosted docker registry I finally got it working. I thought adding some pointers in the configuration file might help the next person who tries this.