### PR TITLE
Add availability to work with Microsoft Azure artifactory

### DIFF
--- a/paclair/docker/docker_registry.py
+++ b/paclair/docker/docker_registry.py
@@ -122,7 +122,7 @@ class DockerRegistry(LoggedObject):
                 raise RegistryAccessError("Error access to : {url} \nCode Error : {status_code}".format(
                     url=url, status_code=resp.status_code))
 
-            token = resp.json()['token']
+            token = resp.json().get('token', '') or resp.json().get('access_token', '')
             self.logger.debug("TOKEN:{token}".format(token=token))
         else:
             token = self.__token


### PR DESCRIPTION
To have availability to scan images that store in Microsoft Azure registry I suggest this fix

Have problem with scanning image from Microsoft Azure registry like:
mirantis.azurecr.io/general/mariadb:10.4.14-bionic-20200812025059 

```
File "/home/sofya/docker-image-scanner/imagescanner/virtenv_paclair/bin/paclair", line 8, in <module>
    sys.exit(main())
  File "/home/sofya/docker-image-scanner/imagescanner/virtenv_paclair/lib/python3.6/site-packages/paclair/__main__.py", line 71, in main
    paclair_object.push(args.plugin, host)
  File "/home/sofya/docker-image-scanner/imagescanner/virtenv_paclair/lib/python3.6/site-packages/paclair/handler.py", line 76, in push
    self._plugins[plugin].push(name)
  File "/home/sofya/docker-image-scanner/imagescanner/virtenv_paclair/lib/python3.6/site-packages/paclair/plugins/abstract_plugin.py", line 53, in push
    return self.clair.post_ancestry(self.create_ancestry(name))
  File "/home/sofya/docker-image-scanner/imagescanner/virtenv_paclair/lib/python3.6/site-packages/paclair/plugins/docker_plugin.py", line 68, in create_ancestry
    return DockerAncestry(self.create_docker_image(name))
  File "/home/sofya/docker-image-scanner/imagescanner/virtenv_paclair/lib/python3.6/site-packages/paclair/ancestries/docker.py", line 19, in __init__
    headers = {'Authorization': "{}".format(docker_image.authorization)}
  File "/home/sofya/docker-image-scanner/imagescanner/virtenv_paclair/lib/python3.6/site-packages/paclair/docker/docker_image.py", line 43, in authorization
    return self.registry.get_authorization(self)
  File "/home/sofya/docker-image-scanner/imagescanner/virtenv_paclair/lib/python3.6/site-packages/paclair/docker/docker_registry.py", line 125, in get_authorization
    token = resp.json()['token']
KeyError: 'token'


```