### PR TITLE
Add ability to work with multi-platform docker images

### DIFF
--- a/paclair/docker/docker_registry.py
+++ b/paclair/docker/docker_registry.py
@@ -144,7 +144,9 @@ class DockerRegistry(LoggedObject):
         resp = requests.get(
             url,
             verify=self.verify,
-            headers={"Authorization": "{}".format(token)}
+            headers={
+                "Accept": "application/vnd.docker.distribution.manifest.v2+json",
+                "Authorization": "{}".format(token)}
         )
 
         if not resp.ok:


### PR DESCRIPTION
Paclair doesn't support multi-platform images like gcr.io/kubernetes-e2e-test-images/sample-apiserver:1.17 and fails with following error:

```Traceback (most recent call last):
  File "/home/sofya/paclair/virt/bin/paclair", line 11, in <module>
    load_entry_point('paclair', 'console_scripts', 'paclair')()
  File "/home/sofya/paclair/paclair/__main__.py", line 71, in main
    paclair_object.push(args.plugin, host)
  File "/home/sofya/paclair/paclair/handler.py", line 76, in push
    self._plugins[plugin].push(name)
  File "/home/sofya/paclair/paclair/plugins/abstract_plugin.py", line 53, in push
    return self.clair.post_ancestry(self.create_ancestry(name))
  File "/home/sofya/paclair/paclair/plugins/docker_plugin.py", line 73, in create_ancestry
    return DockerAncestry(self.create_docker_image(name))
  File "/home/sofya/paclair/paclair/ancestries/docker.py", line 24, in __init__
    for layer in docker_image.get_layers():
  File "/home/sofya/paclair/paclair/docker/docker_image.py", line 86, in get_layers
    fs_layers = manifest['layers']
KeyError: 'layers' 
```
It happens because in case of multi-platform images Docker API returns manifest with mediaType: 'application/vnd.docker.distribution.manifest.list.v2+json' .

To have ability to work with multi-platform images I suggest getting manifest with mediaType: 'application/vnd.docker.distribution.manifest.v2+json' by specifying this mediaType in request Headers.